### PR TITLE
Corrected Block/Renderer registration

### DIFF
--- a/src/main/java/com/jlgm/mmdr/block/MMDRBlock.java
+++ b/src/main/java/com/jlgm/mmdr/block/MMDRBlock.java
@@ -26,10 +26,12 @@ public class MMDRBlock {
 		simpleBlock1ItemBlock = new ItemBlock(simpleBlock1);
 	}
 	
-	public static void registerBlock(){
+	public static void registerBlockRenderers() {
 		RenderItem renderItem = Minecraft.getMinecraft().getRenderItem();
-		
 		renderItem.getItemModelMesher().register(simpleBlock1ItemBlock, 0, new ModelResourceLocation(MMDRConstants.MODID + ":" + "simpleBlock1", "inventory"));
+	}
+	
+	public static void registerBlock(){
 		GameRegistry.register(simpleBlock1);
 		GameRegistry.register(simpleBlock1ItemBlock.setRegistryName(simpleBlock1.getRegistryName()));
 	}

--- a/src/main/java/com/jlgm/mmdr/main/ClientProxy.java
+++ b/src/main/java/com/jlgm/mmdr/main/ClientProxy.java
@@ -16,9 +16,9 @@ public class ClientProxy extends CommonProxy{
 	
 	@Override
 	public void init(FMLInitializationEvent initEvent){
-		MMDRBlock.registerBlock();
-		MMDRItem.registerItem();
 		super.init(initEvent);
+		MMDRBlock.registerBlockRenderers();
+		MMDRItem.registerItem();
 	}
 	
 	@Override

--- a/src/main/java/com/jlgm/mmdr/main/CommonProxy.java
+++ b/src/main/java/com/jlgm/mmdr/main/CommonProxy.java
@@ -23,6 +23,7 @@ public class CommonProxy {
 	}
 	
 	public void init(FMLInitializationEvent initEvent){
+		MMDRBlock.registerBlock();
 	}
 	
 	public void postInit(FMLPostInitializationEvent postInitEvent){


### PR DESCRIPTION
Moved block renderer registration to new method MMDRBlock#registerBlockRenderers, made a call to it from ClientProxy#init, removed renderer registration from MMDRBlock#registerBlock, moved call to MMDRBlock#registerBlock to CommonProxy, also reordered method calls so CommonProxy methods are called first. Should fix issue #8. (#4, not 8 lol)
